### PR TITLE
Fix magic methods skipping validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ $json = '{"number":3}';
 $schema = '{"type": "object","properties": {"number":{ "type": "number" }}}';
 $data = new RootedJsonData($json, $schema);
 echo $data->{"$.number"}; // 3
+echo $data->{"$[number]"}; // 3
 echo "{$data}"; // {"number":3}
 $data->{"$.number"} = "three"; // EXCEPTION
 ```

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -99,7 +99,7 @@ class RootedJsonData
      */
     public function __get($path)
     {
-        return $this->data->get($path);
+        return $this->get($path);
     }
 
     /**
@@ -126,7 +126,7 @@ class RootedJsonData
     }
 
     /**
-     * @see JsonPath\JsonObject::__get()
+     * @see JsonPath\JsonObject::__set()
      *
      * @param mixed $path
      * @param mixed $value
@@ -135,6 +135,6 @@ class RootedJsonData
      */
     public function __set($path, $value)
     {
-        return $this->data->set($path, $value);
+        return $this->set($path, $value);
     }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -29,6 +29,14 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals("Hello", $data->{"$.title"});
     }
 
+    public function testBracketSyntax()
+    {
+        $data = new RootedJsonData();
+        $data->{"$[title]"} = "Hello";
+        $this->assertEquals('{"title":"Hello"}', "{$data}");
+        $this->assertEquals("Hello", $data->{"$[title]"});
+    }
+
     public function testAccessToNonExistentProperties()
     {
         $this->expectExceptionMessage("Property $.city is not set");
@@ -82,6 +90,10 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals($json, "{$data}");
 
         $data->set("$.number", "Alice");
+
+        // Test with magic setter as well.
+        $this->expectExceptionMessage("\$[number] expects a number");
+        $data->{"$[number]"} = "Alice";
     }
 
     public function testJsonPathGetter()


### PR DESCRIPTION
Noticed that the magic getter and setter were bypassing our class's `get()` and `set()` and skipping directly to JsonObject's setter and getter, and the tests were not detecting this. The biggest issue with this is that it will skip validation for the setter.

Also made support for JsonPath bracket syntax more explicit.