### PR TITLE
Improve no property behavior and schema storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor/
 .phpunit*
 .vscode/
+/.idea/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "GPL-3.0-or-later",
     "require": {
         "opis/json-schema": "^1.0",
-        "galbar/jsonpath": "^1.1"
+        "galbar/jsonpath": "^1.1",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4"

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -128,7 +128,7 @@ class RootedJsonData
     }
 
     /**
-     * @see JsonPath\JsonObject::__get()
+     * @see JsonPath\JsonObject::__set()
      *
      * @param mixed $path
      * @param mixed $value
@@ -140,13 +140,27 @@ class RootedJsonData
         return $this->data->set($path, $value);
     }
 
-    public function __isset($name)
+    /**
+     * Check if a property or path is set.
+     *
+     * @param string $path
+     *   Path to check.
+     *
+     * @return bool
+     * /
+    public function __isset(string $path)
     {
         $notSmart = new JsonObject("{$this->data}");
         return $notSmart->get($name) ? true : false;
     }
 
-    public function getSchema() {
+    /**
+     * Get the JSON Schema for the JSON.
+     *
+     * @return string
+     * /
+    public function getSchema()
+    {
         return $this->schema;
     }
 }

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -2,6 +2,8 @@
 
 namespace RootedData;
 
+use InvalidArgumentException;
+use JsonPath\InvalidJsonException;
 use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
 use JsonPath\JsonObject;
@@ -25,13 +27,14 @@ class RootedJsonData
      *   String of JSON data.
      * @param string $schema
      *   JSON schema document for validation.
+     * @throws InvalidJsonException
      */
     public function __construct(string $json = "{}", string $schema = "{}")
     {
         $decoded = json_decode($json);
 
         if (!isset($decoded)) {
-            throw new \InvalidArgumentException("Invalid JSON: " . json_last_error_msg());
+            throw new InvalidArgumentException("Invalid JSON: " . json_last_error_msg());
         }
 
         if (Schema::fromJsonString($schema)) {
@@ -50,20 +53,19 @@ class RootedJsonData
     /**
      * Validate a JsonObject.
      *
-     * @param JsonPath\JsonObject $data
+     * @param JsonObject $data
      *   JsonData object to validate against schema.
      * @param string $schema
      *   JSON Schema string.
      *
-     * @return Opis\JsonSchema\ValidationResult
+     * @return ValidationResult
      *   Validation result object, contains error report if invalid.
      */
     public static function validate(JsonObject $data, string $schema): ValidationResult
     {
         $opiSchema = Schema::fromJsonString($schema);
         $validator = new Validator();
-        $result = $validator->schemaValidation(json_decode("{$data}"), $opiSchema);
-        return $result;
+        return $validator->schemaValidation(json_decode("{$data}"), $opiSchema);
     }
 
     /**
@@ -83,7 +85,7 @@ class RootedJsonData
      * @return mixed
      *   Result of JsonPath\JsonObject::__get()
      */
-    public function get($path)
+    public function get(string $path)
     {
         if ($this->__isset($path) === false) {
             return null;
@@ -92,14 +94,14 @@ class RootedJsonData
     }
 
     /**
-     * @see JsonPath\JsonObject::__get()
-     *
      * @param string $path
      *
      * @return mixed
      *   Result of JsonPath\JsonObject::__get()
+     * @see \JsonPath\JsonObject::__get()
+     *
      */
-    public function __get($path)
+    public function __get(string $path)
     {
         return $this->data->get($path);
     }
@@ -110,9 +112,10 @@ class RootedJsonData
      * @param string $path
      * @param mixed $value
      *
-     * @return JsonPath\JsonObject
+     * @return JsonObject
+     * @throws InvalidJsonException
      */
-    public function set($path, $value)
+    public function set(string $path, $value)
     {
         $validationJsonObject = new JsonObject((string) $this->data);
         $validationJsonObject->set($path, $value);
@@ -128,12 +131,12 @@ class RootedJsonData
     }
 
     /**
-     * @see JsonPath\JsonObject::__get()
+     * @see \JsonPath\JsonObject::__get()
      *
      * @param mixed $path
      * @param mixed $value
      *
-     * @return JsonPath\JsonObject
+     * @return JsonObject
      */
     public function __set($path, $value)
     {

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -128,7 +128,7 @@ class RootedJsonData
     }
 
     /**
-     * @see JsonPath\JsonObject::__set()
+     * @see JsonPath\JsonObject::__get()
      *
      * @param mixed $path
      * @param mixed $value
@@ -140,27 +140,13 @@ class RootedJsonData
         return $this->data->set($path, $value);
     }
 
-    /**
-     * Check if a property or path is set.
-     *
-     * @param string $path
-     *   Path to check.
-     *
-     * @return bool
-     * /
-    public function __isset(string $path)
+    public function __isset($name)
     {
         $notSmart = new JsonObject("{$this->data}");
         return $notSmart->get($name) ? true : false;
     }
 
-    /**
-     * Get the JSON Schema for the JSON.
-     *
-     * @return string
-     * /
-    public function getSchema()
-    {
+    public function getSchema() {
         return $this->schema;
     }
 }

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -34,7 +34,9 @@ class RootedJsonData
             throw new \InvalidArgumentException("Invalid JSON: " . json_last_error_msg());
         }
 
-        $this->schema = Schema::fromJsonString($schema);
+        if (Schema::fromJsonString($schema)) {
+            $this->schema = $schema;
+        }
 
         $data = new JsonObject($json, true);
         $result = self::validate($data, $this->schema);
@@ -50,16 +52,17 @@ class RootedJsonData
      *
      * @param JsonPath\JsonObject $data
      *   JsonData object to validate against schema.
-     * @param Opis\JsonSchema\Schema $schema
-     *   And Opis Json-Schema schema object to validate data against.
+     * @param string $schema
+     *   JSON Schema string.
      *
      * @return Opis\JsonSchema\ValidationResult
      *   Validation result object, contains error report if invalid.
      */
-    public static function validate(JsonObject $data, Schema $schema): ValidationResult
+    public static function validate(JsonObject $data, string $schema): ValidationResult
     {
+        $opiSchema = Schema::fromJsonString($schema);
         $validator = new Validator();
-        $result = $validator->schemaValidation(json_decode("{$data}"), $schema);
+        $result = $validator->schemaValidation(json_decode("{$data}"), $opiSchema);
         return $result;
     }
 

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -82,11 +82,10 @@ class RootedJsonData
      */
     public function get($path)
     {
-        $result = $this->data->get($path);
-        if ($result === false) {
-            throw new \Exception("Property {$path} is not set");
+        if ($this->__isset($path) === false) {
+            return null;
         }
-        return $result;
+        return $this->data->get($path);
     }
 
     /**
@@ -99,7 +98,7 @@ class RootedJsonData
      */
     public function __get($path)
     {
-        return $this->get($path);
+        return $this->data->get($path);
     }
 
     /**
@@ -126,7 +125,7 @@ class RootedJsonData
     }
 
     /**
-     * @see JsonPath\JsonObject::__set()
+     * @see JsonPath\JsonObject::__get()
      *
      * @param mixed $path
      * @param mixed $value
@@ -135,6 +134,16 @@ class RootedJsonData
      */
     public function __set($path, $value)
     {
-        return $this->set($path, $value);
+        return $this->data->set($path, $value);
+    }
+
+    public function __isset($name)
+    {
+        $notSmart = new JsonObject("{$this->data}");
+        return $notSmart->get($name) ? true : false;
+    }
+
+    public function getSchema() {
+        return $this->schema;
     }
 }

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -149,7 +149,8 @@ class RootedJsonData
         return $notSmart->get($name) ? true : false;
     }
 
-    public function getSchema() {
+    public function getSchema()
+    {
         return $this->schema;
     }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -6,6 +6,7 @@ namespace RootedDataTest;
 use PHPUnit\Framework\TestCase;
 use RootedData\RootedJsonData;
 use Opis\JsonSchema\Exception\InvalidSchemaException;
+use Opis\JsonSchema\Schema;
 use RootedData\Exception\ValidationException;
 
 class RootedJsonDataTest extends TestCase
@@ -39,9 +40,9 @@ class RootedJsonDataTest extends TestCase
 
     public function testAccessToNonExistentProperties()
     {
-        $this->expectExceptionMessage("Property $.city is not set");
         $data = new RootedJsonData();
-        $city = $data->get("$.city");
+        $this->assertNull($data->get("$.city"));
+        $this->assertFalse(isset($data->{"$.city"}));
     }
 
     public function testJsonFormat()
@@ -109,5 +110,13 @@ class RootedJsonDataTest extends TestCase
         $data = new RootedJsonData($json);
         $data->set("$.container.number", 52);
         $this->assertEquals(52, $data->get("$.container.number"));
+    }
+
+    public function testSchemaGetter()
+    {
+        $json = '{"number":51}';
+        $schema = '{"type": "object","properties":{"number":{"type":"number"}}}';
+        $data = new RootedJsonData($json, $schema);
+        $this->assertInstanceOf(Schema::class, $data->getSchema());
     }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -117,6 +117,6 @@ class RootedJsonDataTest extends TestCase
         $json = '{"number":51}';
         $schema = '{"type": "object","properties":{"number":{"type":"number"}}}';
         $data = new RootedJsonData($json, $schema);
-        $this->assertInstanceOf(Schema::class, $data->getSchema());
+        $this->assertEquals($schema, $data->getSchema());
     }
 }


### PR DESCRIPTION
Fixes two issues:

1. It was hard to tell if a property was actually set. Now, requesting a non-existant property will return `null` instead of `false`, and the magic `__isset()` method has been added.
2. We were storing the schema as an Opis `Schema` object, but that's not very useful because it doesn't have any way to convert back into a string. Now we just store the string and instantiate a Schema object internally where needed.