### PR TITLE
Revert broken getter and setter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 vendor/
 .phpunit*
 .vscode/
+/.idea/codeStyles/codeStyleConfig.xml
+/composer.lock
+/.idea/modules.xml
+/.idea/php.xml
+/.idea/RootedJsonData.iml
+/.idea/vcs.xml
+/.idea/workspace.xml

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -103,7 +103,7 @@ class RootedJsonData
      */
     public function __get(string $path)
     {
-        return $this->data->get($path);
+        return $this->get($path);
     }
 
     /**
@@ -148,7 +148,7 @@ class RootedJsonData
      */
     public function __set($path, $value)
     {
-        return $this->data->set($path, $value);
+        return $this->set($path, $value);
     }
 
     public function __isset($name)

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -112,6 +112,7 @@ class RootedJsonData
      */
     public function set($path, $value)
     {
+        $this->normalizeSetValue($value);
         $validationJsonObject = new JsonObject((string) $this->data);
         $validationJsonObject->set($path, $value);
 
@@ -123,6 +124,13 @@ class RootedJsonData
         }
 
         return $this->data->set($path, $value);
+    }
+
+    private function normalizeSetValue(&$value)
+    {
+        if ($value instanceof RootedJsonData) {
+            $value = $value->{"$"};
+        }
     }
 
     /**

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -110,4 +110,17 @@ class RootedJsonDataTest extends TestCase
         $data->set("$.container.number", 52);
         $this->assertEquals(52, $data->get("$.container.number"));
     }
+
+    public function testAddJsonData()
+    {
+        $json = '{"container":""}';
+        $subJson = '{"number":51}';
+        $data = new RootedJsonData($json);
+        $data->set("$.container", new RootedJsonData($subJson));
+        $this->assertEquals(51, $data->get("$.container.number"));
+
+        $data2 = new RootedJsonData($json);
+        $data2->set("$.container", json_encode($subJson));
+        $this->assertEquals(51, $data->get("$.container.number"));
+    }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -88,12 +88,17 @@ class RootedJsonDataTest extends TestCase
         $json = '{"number":51}';
         $schema = '{"type":"object","properties": {"number":{ "type":"number"}}}';
         $data = new RootedJsonData($json, $schema);
-        $this->assertEquals($json, "{$data}");
 
         $data->set("$.number", "Alice");
+    }
 
-        // Test with magic setter as well.
+    public function testJsonIntegrityFailureMagicSetter()
+    {
         $this->expectExceptionMessage("\$[number] expects a number");
+
+        $json = '{"number":51}';
+        $schema = '{"type":"object","properties": {"number":{ "type":"number"}}}';
+        $data = new RootedJsonData($json, $schema);
         $data->{"$[number]"} = "Alice";
     }
 


### PR DESCRIPTION
Did something wrong and reverted magic getter and setter to bypass RootedJsonData's additional logic in `get()` and especially `set()`. Reverts this again and fixes a test that was giving false positives.