### PR TITLE
Normalize set values when passing objects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     environment:
       CC_TEST_REPORTER_ID: 8ec926841c6dfead9c848fd063c569e11b06be11442a8175d588e10607ee2150
+      XDEBUG_MODE: coverage
     docker:
       - image: circleci/php:7-cli-node-browsers-legacy
     working_directory: ~/repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 vendor/
 .phpunit*
 .vscode/
+/.idea/codeStyles/codeStyleConfig.xml
+/composer.lock
+/.idea/modules.xml
+/.idea/php.xml
+/.idea/RootedJsonData.iml
+/.idea/vcs.xml
+/.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 vendor/
 .phpunit*
 .vscode/
-<<<<<<< HEAD
 /.idea/codeStyles/codeStyleConfig.xml
 /composer.lock
 /.idea/modules.xml
@@ -9,7 +8,3 @@ vendor/
 /.idea/RootedJsonData.iml
 /.idea/vcs.xml
 /.idea/workspace.xml
-=======
-/.idea/
-/composer.lock
->>>>>>> master

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -103,7 +103,7 @@ class RootedJsonData
      */
     public function __get(string $path)
     {
-        return $this->data->get($path);
+        return $this->get($path);
     }
 
     /**
@@ -148,7 +148,7 @@ class RootedJsonData
      */
     public function __set($path, $value)
     {
-        return $this->data->set($path, $value);
+        return $this->set($path, $value);
     }
 
     public function __isset($name)

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -75,7 +75,17 @@ class RootedJsonData
      */
     public function __toString()
     {
-        return (string) $this->data;
+        return $this->data->getJson();
+    }
+    
+    /**
+     * Return pretty-formatted JSON string
+     *
+     * @return string
+     */
+    public function pretty()
+    {
+        return $this->data->getJson(JSON_PRETTY_PRINT);
     }
 
     /**

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -112,6 +112,7 @@ class RootedJsonData
      */
     public function set($path, $value)
     {
+        $this->normalizeSetValue($value);
         $validationJsonObject = new JsonObject((string) $this->data);
         $validationJsonObject->set($path, $value);
 
@@ -123,6 +124,13 @@ class RootedJsonData
         }
 
         return $this->data->set($path, $value);
+    }
+
+    private function normalizeSetValue(&$value)
+    {
+        if ($value instanceof RootedJsonData) {
+            $value = $value->{"$"};
+        }
     }
 
     /**

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -140,6 +140,11 @@ class RootedJsonData
         return $this->data->set($path, $value);
     }
 
+    /**
+     * Ensure consistent data type whether RootedJsonData or stdClass.
+     *
+     * @param mixed $value
+     */
     private function normalizeSetValue(&$value)
     {
         if ($value instanceof RootedJsonData) {

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -151,12 +151,26 @@ class RootedJsonData
         return $this->set($path, $value);
     }
 
-    public function __isset($name)
+    /**
+     * Magic __isset method for a path.
+     *
+     * @param mixed $path
+     *   Check if a property at this path is set or not.
+     *
+     * @return bool
+     */
+    public function __isset($path)
     {
         $notSmart = new JsonObject("{$this->data}");
-        return $notSmart->get($name) ? true : false;
+        return $notSmart->get($path) ? true : false;
     }
 
+    /**
+     * Get the JSON Schema as a string.
+     *
+     * @return string
+     *   The JSON Schema for this object.
+     */
     public function getSchema()
     {
         return $this->schema;

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -110,4 +110,17 @@ class RootedJsonDataTest extends TestCase
         $data->set("$.container.number", 52);
         $this->assertEquals(52, $data->get("$.container.number"));
     }
+
+    public function testAddJsonData()
+    {
+        $json = '{"container":""}';
+        $subJson = '{"number":51}';
+        $data = new RootedJsonData($json);
+        $data->set("$.container", new RootedJsonData($subJson));
+        $this->assertEquals(51, $data->get("$.container.number"));
+
+        $data2 = new RootedJsonData($json);
+        $data2->set("$.container", json_encode($subJson));
+        $this->assertEquals(51, $data->get("$.container.number"));
+    }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -109,6 +109,9 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals(51, $data->get("$.container.number"));
     }
 
+    /**
+     * Simple set by JSON path.
+     */
     public function testJsonPathSetter()
     {
         $json = '{"container":{"number":51}}';

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -102,6 +102,9 @@ class RootedJsonDataTest extends TestCase
         $data->{"$[number]"} = "Alice";
     }
 
+    /**
+     * Simple get value from JSON path.
+     */
     public function testJsonPathGetter()
     {
         $json = '{"container":{"number":51}}';

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -92,6 +92,9 @@ class RootedJsonDataTest extends TestCase
         $data->set("$.number", "Alice");
     }
 
+    /**
+     * Do schemas still work with magic setter?
+     */
     public function testJsonIntegrityFailureMagicSetter()
     {
         $this->expectExceptionMessage("\$[number] expects a number");

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -119,15 +119,20 @@ class RootedJsonDataTest extends TestCase
 
     public function testAddJsonData()
     {
-        $json = '{"container":""}';
+        // Test adding RootedJsonData structure.
+        $json = '{}';
+        $containerSchema = '{"type":"object","properties":{"number":{"type":"number"}}}';
+        $schema = '{"type":"object","properties":{"container":'.$containerSchema.'}}';
         $subJson = '{"number":51}';
-        $data = new RootedJsonData($json);
+        $data = new RootedJsonData($json, $schema);
         $data->set("$.container", new RootedJsonData($subJson));
         $this->assertEquals(51, $data->get("$.container.number"));
-
-        $data2 = new RootedJsonData($json);
-        $data2->set("$.container", json_encode($subJson));
-        $this->assertEquals(51, $data->get("$.container.number"));
+        
+        // If we add stdClass object, it should be work and be an array.
+        $data2 = new RootedJsonData($json, $schema);
+        $data2->set("$.container", json_decode($subJson));
+        $this->assertEquals(51, $data2->get("$.container.number"));
+        $this->assertIsArray($data2->get("$.container"));
     }
     
     public function testSchemaGetter()

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -88,12 +88,17 @@ class RootedJsonDataTest extends TestCase
         $json = '{"number":51}';
         $schema = '{"type":"object","properties": {"number":{ "type":"number"}}}';
         $data = new RootedJsonData($json, $schema);
-        $this->assertEquals($json, "{$data}");
 
         $data->set("$.number", "Alice");
+    }
 
-        // Test with magic setter as well.
+    public function testJsonIntegrityFailureMagicSetter()
+    {
         $this->expectExceptionMessage("\$[number] expects a number");
+
+        $json = '{"number":51}';
+        $schema = '{"type":"object","properties": {"number":{ "type":"number"}}}';
+        $data = new RootedJsonData($json, $schema);
         $data->{"$[number]"} = "Alice";
     }
 

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -11,7 +11,7 @@ use RootedData\Exception\ValidationException;
 
 class RootedJsonDataTest extends TestCase
 {
-    public function testSeamlessExperience()
+    public function testJsonInOut()
     {
         $data = new RootedJsonData();
         $data->set("$.title", "Hello");
@@ -117,6 +117,9 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals(52, $data->get("$.container.number"));
     }
 
+    /**
+     * Adding JSON structures in multiple formats should have predictable results.
+     */
     public function testAddJsonData()
     {
         // Test adding RootedJsonData structure.
@@ -135,11 +138,25 @@ class RootedJsonDataTest extends TestCase
         $this->assertIsArray($data2->get("$.container"));
     }
     
+    /**
+     * getSchema() should return the same string that was provided to constructor.
+     */
     public function testSchemaGetter()
     {
         $json = '{"number":51}';
         $schema = '{"type": "object","properties":{"number":{"type":"number"}}}';
         $data = new RootedJsonData($json, $schema);
         $this->assertEquals($schema, $data->getSchema());
+    }
+
+    /**
+     * Regular string should be one line, pretty() should return multiple lines.
+     */
+    public function testPretty()
+    {
+        $json = '{"number":51}';
+        $data = new RootedJsonData($json);
+        $this->assertEquals(0, substr_count("$data", "\n"));
+        $this->assertEquals(2, substr_count($data->pretty(), "\n"));
     }
 }


### PR DESCRIPTION
A strange behavior inherited from the JsonObeject class means that for an existing RootedJsonData object, setting a property by passing an object, in particular a stdClass resulting from `json_decode` will cause the full object to be stored at that level of the data structure. Validation still works but retrieving the value after setting it will return the same stdObeject, when we would expect any `get()` to retrieve an `array`. 

By normalizing incoming objects we avoid this inconsistency. See the new `testAddJsonData()` for examples.