### PR TITLE
Add wrapper for add()

### DIFF
--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -204,11 +204,23 @@ class RootedJsonData
      * @param string $field
      *   Key if adding key/value pair
      *
+     * @return JsonObject
+     * @throws InvalidJsonException
+     *
      * @see JsonPath\JsonObject::add()
      */
     public function add($path, $value, $field = null)
     {
         $this->normalizeSetValue($value);
-        $this->data->add($path, $value, $field);
+        $validationJsonObject = new JsonObject((string) $this->data);
+        $validationJsonObject->add($path, $value, $field);
+
+        $result = self::validate($validationJsonObject, $this->schema);
+        if (!$result->isValid()) {
+            $message = "JSON Schema validation failed.";
+            throw new ValidationException($message, $result);
+        }
+
+        return $this->data->add($path, $value, $field);
     }
 }

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -193,4 +193,22 @@ class RootedJsonData
     {
         return $this->schema;
     }
+
+    /**
+     * Wrapper for JsonObject add() method
+     *
+     * @param string $path
+     *   Path to an array
+     * @param mixed $value
+     *   Value to add
+     * @param string $field
+     *   Key if adding key/value pair
+     *
+     * @see JsonPath\JsonObject::add()
+     */
+    public function add($path, $value, $field = null)
+    {
+        $this->normalizeSetValue($value);
+        $this->data->add($path, $value, $field);
+    }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -170,7 +170,7 @@ class RootedJsonDataTest extends TestCase
     }
 
     /**
-     * Adds an elements to an array.
+     * Adds string elements to an array.
      */
     public function testAdd()
     {
@@ -181,7 +181,7 @@ class RootedJsonDataTest extends TestCase
     }
 
     /**
-     * Adds an elements to an array.
+     * Adds object elements to an array.
      */
     public function testAddObject()
     {
@@ -192,7 +192,7 @@ class RootedJsonDataTest extends TestCase
     }
 
     /**
-     * If an array is provided, adding elements that match array should work,
+     * If a schema is provided, adding elements that match array should work,
      * elements that violate schema will fail.
      */
     public function testAddWithSchema()

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -168,4 +168,15 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals(0, substr_count("$data", "\n"));
         $this->assertEquals(2, substr_count($data->pretty(), "\n"));
     }
+
+    /**
+     * Adds an elements to an array.
+     */
+    public function testAdd()
+    {
+        $json = '{"numbers":["zero","one","two"]}';
+        $data = new RootedJsonData($json);
+        $data->add("$.numbers", "three");
+        $this->assertEquals("three", $data->{"$.numbers[3]"});
+    }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -179,4 +179,30 @@ class RootedJsonDataTest extends TestCase
         $data->add("$.numbers", "three");
         $this->assertEquals("three", $data->{"$.numbers[3]"});
     }
+
+    /**
+     * Adds an elements to an array.
+     */
+    public function testAddObject()
+    {
+        $json = '{"numbers":[{"name":"zero","value":0}]}';
+        $data = new RootedJsonData($json);
+        $data->add("$.numbers", ["name" => "one", "value" => 1]);
+        $this->assertEquals("one", current($data->{"$.numbers[?(@.value == 1)].name"}));
+    }
+
+    /**
+     * If an array is provided, adding elements that match array should work,
+     * elements that violate schema will fail.
+     */
+    public function testAddWithSchema()
+    {
+        $json = '{"numbers":["zero","one"]}';
+        $schema = '{"type": "object","properties":{"numbers":{"type":"array","items":{"type":"string"}}}}';
+        $data = new RootedJsonData($json, $schema);
+        $data->add("$.numbers", "two");
+        $this->assertEquals("two", $data->{"$.numbers[2]"});
+        $this->expectException(ValidationException::class);
+        $data->add("$.numbers", ["name" => "three", "value" => 3]);
+    }
 }


### PR DESCRIPTION
There is currently no way to add an element to an existing array. While in the future we might want to add a `push()` method that would work with only arrays and validate the path more strictly, this gets us what we need without much bloat on the RootedJsonData class. 

See `RootedJsonDatatTest::testAdd()` for a working example of appending a string to an existing string of values.

See [`JsonPath\JsonObject::add()`](https://github.com/Galbar/JsonPath-PHP/blob/fad21d2b74e396e82e4bd7955cbd4fcbeee060b2/src/Galbar/JsonPath/JsonObject.php#L353) for the original function being wrapped here.