### PR TITLE
Add remove() and __unset(), update JsonPath

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 plugins:
   phpcodesniffer:
     enabled: true
@@ -14,3 +14,4 @@ exclude_patterns:
  - ".circleci/"
  - ".gitignore"
  - "docs/"
+ - "tests/"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "galbar/jsonpath": "^1.1",
+        "galbar/jsonpath": "^3.0",
         "opis/json-schema": "^1.0.8"
     },
     "require-dev": {

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -183,6 +183,12 @@ class RootedJsonData
         return $notSmart->get($path) ? true : false;
     }
 
+    /**
+     * Magic __unset method, detects field from path.
+     *
+     * @param mixed $path
+     *   Path to unset, including specific field.
+     */
     public function __unset($path)
     {
         $exploded = explode(".", $path);
@@ -192,12 +198,15 @@ class RootedJsonData
     }
 
     /**
-     * Wrapper for JsonObject::remove() method
+     * Wrapper for JsonObject::remove() method, plus validation.
      *
      * @param mixed $path
-     *   Check if a property at this path is set or not.
+     *   jsonPath.
+     * @param mixed $field
+     *   Field to remove.
      *
-     * @return bool
+     * @return \JsonPath\JsonObject
+     *  Modified object (self).
      */
     public function remove($path, $field)
     {

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -183,6 +183,14 @@ class RootedJsonData
         return $notSmart->get($path) ? true : false;
     }
 
+    public function __unset($path)
+    {
+        $exploded = explode(".", $path);
+        $field = array_pop($exploded);
+        $imploded = implode(".", $exploded);
+        $this->remove($imploded, $field);
+    }
+
     /**
      * Wrapper for JsonObject::remove() method
      *

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -184,6 +184,29 @@ class RootedJsonData
     }
 
     /**
+     * Wrapper for JsonObject::remove() method
+     *
+     * @param mixed $path
+     *   Check if a property at this path is set or not.
+     *
+     * @return bool
+     */
+    public function remove($path, $field)
+    {
+        $validationJsonObject = new JsonObject((string) $this->data);
+        $validationJsonObject->remove($path, $field);
+
+        $result = self::validate($validationJsonObject, $this->schema);
+        if (!$result->isValid()) {
+            $keywordArgs = $result->getFirstError()->keywordArgs();
+            $message = "{$path} expects a {$keywordArgs['expected']}";
+            throw new ValidationException($message, $result);
+        }
+
+        return $this->data->remove($path, $field);
+    }
+
+    /**
      * Get the JSON Schema as a string.
      *
      * @return string

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -225,7 +225,19 @@ class RootedJsonDataTest extends TestCase
     public function testRemove()
     {
         $json = '{"field1":"foo","field2":"bar"}';
-        $schema = '{"type": "object","required":["field1"],"properties":{"field1":{"type":"string"},"field2":{"type":"string"}}}';
+        $schema = '
+            {
+                "type": "object",
+                "required":["field1"],
+                "properties": {
+                    "field1": {
+                        "type":"string"
+                    },
+                    "field2": {
+                        "type":"string"
+                    }
+                }
+            }';
         $data = new RootedJsonData($json, $schema);
         $data->remove("$", "field2");
         $this->assertEquals("foo", $data->{"$.field1"});
@@ -240,7 +252,19 @@ class RootedJsonDataTest extends TestCase
     public function testUnset()
     {
         $json = '{"field1":"foo","field2":"bar"}';
-        $schema = '{"type": "object","required":["field1"],"properties":{"field1":{"type":"string"},"field2":{"type":"string"}}}';
+        $schema = '
+            {
+                "type": "object",
+                "required":["field1"],
+                "properties": {
+                    "field1": {
+                        "type":"string"
+                    },
+                    "field2": {
+                        "type":"string"
+                    }
+                }
+            }';
         $data = new RootedJsonData($json, $schema);
         unset($data->{"$.field2"});
         $this->assertEquals("foo", $data->{"$.field1"});

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -228,7 +228,23 @@ class RootedJsonDataTest extends TestCase
         $schema = '{"type": "object","required":["field1"],"properties":{"field1":{"type":"string"},"field2":{"type":"string"}}}';
         $data = new RootedJsonData($json, $schema);
         $data->remove("$", "field2");
+        $this->assertEquals("foo", $data->{"$.field1"});
         $this->expectException(ValidationException::class);
         $data->remove("$", "field1");
+    }
+
+    /**
+     * If a schema is provided, adding elements that match array should work,
+     * elements that violate schema will fail.
+     */
+    public function testUnset()
+    {
+        $json = '{"field1":"foo","field2":"bar"}';
+        $schema = '{"type": "object","required":["field1"],"properties":{"field1":{"type":"string"},"field2":{"type":"string"}}}';
+        $data = new RootedJsonData($json, $schema);
+        unset($data->{"$.field2"});
+        $this->assertEquals("foo", $data->{"$.field1"});
+        $this->expectException(ValidationException::class);
+        unset($data->{"$.field1"});
     }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -217,4 +217,18 @@ class RootedJsonDataTest extends TestCase
         $this->expectException(ValidationException::class);
         $data->add("$.numbers", ["name" => "three", "value" => 3]);
     }
+
+    /**
+     * If a schema is provided, adding elements that match array should work,
+     * elements that violate schema will fail.
+     */
+    public function testRemove()
+    {
+        $json = '{"field1":"foo","field2":"bar"}';
+        $schema = '{"type": "object","required":["field1"],"properties":{"field1":{"type":"string"},"field2":{"type":"string"}}}';
+        $data = new RootedJsonData($json, $schema);
+        $data->remove("$", "field2");
+        $this->expectException(ValidationException::class);
+        $data->remove("$", "field1");
+    }
 }


### PR DESCRIPTION
This adds a remove() method, which is just a wrapper for JsonPath::remove, and also an magic __unset() method that attempts to unset a property using remove(). Both will validate before modifying the object.

So we can do on the following:

```json
{
  "field1": "foo",
  "field2": "bar"
}
```

1. `$rootedDataObject->remove("$", "field2");`
2. `unset($rootedDataObject->{"$.field2");`

Either will result in:

```json
{
  "field1": "foo",
}
```


Also updates to latest release of JsonPath library.