### PR TITLE
Support PHP 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       tag: << parameters.version >>
     parameters:
       version:
-        default: "7.4"
+        default: "8.2"
         description: The `cimg/php` Docker image version tag.
         type: string
       install-flags:
@@ -154,7 +154,7 @@ jobs:
       - when:
           condition:
             and:
-              - equal: [ "8.1", <<parameters.version>> ]
+              - equal: [ "8.2", <<parameters.version>> ]
               - equal: [ "", <<parameters.install-flags>> ]
           steps:
             - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
           condition:
             not:
               and:
-                - equal: [ "8.1", <<parameters.version>> ]
+                - equal: [ "8.2", <<parameters.version>> ]
                 - equal: [ "", <<parameters.install-flags>> ]
           steps:
             - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
       - matrix-conditions:
           matrix:
             parameters:
-              version: ["8.2", "7.4", "8.0", "8.1"]
+              version: ["7.4", "8.0", "8.1", "8.2"]
               install-flags: ["", "--prefer-lowest"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,5 +176,5 @@ workflows:
       - matrix-conditions:
           matrix:
             parameters:
-              version: ["7.4", "8.0", "8.1"]
+              version: ["8.2", "7.4", "8.0", "8.1"]
               install-flags: ["", "--prefer-lowest"]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Exclude build/test files from archive
+/.circleci        export-ignore
+/test             export-ignore
+/.editorconfig    export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/phpcs.xml        export-ignore
+/phpunit.xml      export-ignore
+/rector.php       export-ignore
+
+# Configure diff output for .php and .phar files.
+*.php diff=php

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.4",
         "rector/rector": "^0.15.19",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "symfony/phpunit-bridge": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" stopOnFailure="false" stopOnError="false" verbose="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         verbose="false">
   <coverage processUncoveredFiles="true">
     <include>
-      <directory suffix=".php">src</directory>
+      <directory>src</directory>
     </include>
   </coverage>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
+  <php>
+    <!-- Don't fail for external dependencies. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+  </php>
   <testsuites>
     <testsuite name="all">
-      <directory suffix="Test.php" phpVersion="7.2" phpVersionOperator="&gt;=">tests</directory>
+      <directory>tests</directory>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -3,15 +3,43 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->paths([
     __DIR__ . '/src',
-    __DIR__ . '/tests',
+    __DIR__ . '/test',
+    __DIR__ . '/rector.php',
     ]);
 
     $rectorConfig->sets([
+    // Please no dead code or unneeded variables.
+    SetList::DEAD_CODE,
+    // Try to figure out type hints.
+    SetList::TYPE_DECLARATION,
+    // Bring us up to PHP 7.4.
     LevelSetList::UP_TO_PHP_74,
     ]);
+
+    $rectorConfig->skip([
+    // Don't throw errors on JSON parse problems. Yet.
+    // @todo Throw errors and deal with them appropriately.
+    JsonThrowOnErrorRector::class,
+    // We like our tags.
+    RemoveUselessParamTagRector::class,
+    RemoveUselessReturnTagRector::class,
+    RemoveUselessVarTagRector::class,
+    ]);
+
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
 };

--- a/rector.php
+++ b/rector.php
@@ -16,28 +16,27 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->phpVersion(PhpVersion::PHP_74);
 
     $rectorConfig->paths([
-    __DIR__ . '/src',
-    __DIR__ . '/test',
-    __DIR__ . '/rector.php',
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+        __DIR__ . '/rector.php',
     ]);
 
     $rectorConfig->sets([
-    // Please no dead code or unneeded variables.
-    SetList::DEAD_CODE,
-    // Try to figure out type hints.
-    SetList::TYPE_DECLARATION,
-    // Bring us up to PHP 7.4.
-    LevelSetList::UP_TO_PHP_74,
+        // Please no dead code or unneeded variables.
+        SetList::DEAD_CODE,
+        // Try to figure out type hints.
+        SetList::TYPE_DECLARATION,
+        SetList::PHP_82,
     ]);
 
     $rectorConfig->skip([
-    // Don't throw errors on JSON parse problems. Yet.
-    // @todo Throw errors and deal with them appropriately.
-    JsonThrowOnErrorRector::class,
-    // We like our tags.
-    RemoveUselessParamTagRector::class,
-    RemoveUselessReturnTagRector::class,
-    RemoveUselessVarTagRector::class,
+        // Don't throw errors on JSON parse problems. Yet.
+        // @todo Throw errors and deal with them appropriately.
+        JsonThrowOnErrorRector::class,
+        // We like our tags.
+        RemoveUselessParamTagRector::class,
+        RemoveUselessReturnTagRector::class,
+        RemoveUselessVarTagRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -13,10 +13,8 @@ class ValidationException extends \InvalidArgumentException
 {
     /**
      * Validation result report.
-     *
-     * @var ValidationResult
      */
-    private $validationResult;
+    private ValidationResult $validationResult;
 
     /**
      * @param string $message
@@ -36,7 +34,7 @@ class ValidationException extends \InvalidArgumentException
      * @return ValidationResult
      *   Validation result report.
      */
-    public function getResult()
+    public function getResult(): ValidationResult
     {
         return $this->validationResult;
     }

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -14,7 +14,7 @@ class ValidationException extends \InvalidArgumentException
     /**
      * Validation result report.
      *
-     * @var Opis\JsonSchema\ValidationResult
+     * @var ValidationResult
      */
     private $validationResult;
 
@@ -33,7 +33,7 @@ class ValidationException extends \InvalidArgumentException
     /**
      * Get the validation result object.
      *
-     * @return Opis\JsonSchema\ValidationResult
+     * @return ValidationResult
      *   Validation result report.
      */
     public function getResult()

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -17,8 +17,8 @@ use RootedData\Exception\ValidationException;
 class RootedJsonData
 {
 
-    private $schema;
-    private $data;
+    private ?string $schema = null;
+    private JsonObject $data;
 
     /**
      * Constructor method.
@@ -145,7 +145,7 @@ class RootedJsonData
      *
      * @param mixed $value
      */
-    private function normalizeSetValue(&$value)
+    private function normalizeSetValue(&$value): void
     {
         if ($value instanceof RootedJsonData) {
             $value = $value->{"$"};
@@ -164,7 +164,7 @@ class RootedJsonData
      *
      * @return JsonObject
      */
-    public function __set($path, $value)
+    public function __set(string $path, $value)
     {
         return $this->set($path, $value);
     }
@@ -205,7 +205,7 @@ class RootedJsonData
      * @param mixed $field
      *   Field to remove.
      *
-     * @return \JsonPath\JsonObject
+     * @return JsonObject
      *  Modified object (self).
      */
     public function remove($path, $field)

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -226,10 +226,10 @@ class RootedJsonData
     /**
      * Get the JSON Schema as a string.
      *
-     * @return string
+     * @return string|null
      *   The JSON Schema for this object.
      */
-    public function getSchema()
+    public function getSchema(): ?string
     {
         return $this->schema;
     }


### PR DESCRIPTION
- Adds PHP 8.2 to the testing matrix.
- Adds `.gitattributes` so packages exclude tests, etc.
- Rector adds some code quality.