### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       tag: << parameters.version >>
     parameters:
       version:
-        default: "8.3"
+        default: "8.4"
         description: The `cimg/php` Docker image version tag.
         type: string
       install-flags:
@@ -154,7 +154,7 @@ jobs:
       - when:
           condition:
             and:
-              - equal: [ "8.3", <<parameters.version>> ]
+              - equal: [ "8.4", <<parameters.version>> ]
               - equal: [ "", <<parameters.install-flags>> ]
           steps:
             - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
           condition:
             not:
               and:
-                - equal: [ "8.3", <<parameters.version>> ]
+                - equal: [ "8.4", <<parameters.version>> ]
                 - equal: [ "", <<parameters.install-flags>> ]
           steps:
             - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
       - matrix-conditions:
           matrix:
             parameters:
-              version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+              version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
               install-flags: ["", "--prefer-lowest"]

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "opis/json-schema": "^1.0.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "rector/rector": "^0.15.19",
+        "phpunit/phpunit": "^9.6",
+        "rector/rector": "^2.0.0",
         "squizlabs/php_codesniffer": "^3.7",
-        "symfony/phpunit-bridge": "^7.0"
+        "symfony/phpunit-bridge": "^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "ext-json": "*",
         "galbar/jsonpath": "^3.0",
-        "opis/json-schema": "^1.0.8"
+        "opis/json-schema": "^1.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.20",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "opis/json-schema": "^1.0.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.20",
         "rector/rector": "^2.0.0",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^7.2"

--- a/rector.php
+++ b/rector.php
@@ -6,15 +6,13 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->paths([
         __DIR__ . '/src',
-        __DIR__ . '/test',
+        __DIR__ . '/tests',
         __DIR__ . '/rector.php',
     ]);
 
@@ -27,9 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
-        // Don't throw errors on JSON parse problems. Yet.
-        // @todo Throw errors and deal with them appropriately.
-        JsonThrowOnErrorRector::class,
         // We like our tags.
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -11,7 +11,7 @@ use RootedData\Exception\ValidationException;
 
 class RootedJsonDataTest extends TestCase
 {
-    public function testJsonInOut()
+    public function testJsonInOut(): void
     {
         $data = new RootedJsonData();
         $data->set("$.title", "Hello");
@@ -22,7 +22,7 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals('{"title":"Hello","publisher":{"name":"Frank"}}', (string) $data);
     }
 
-    public function testMagicGetterAndSetter()
+    public function testMagicGetterAndSetter(): void
     {
         $data = new RootedJsonData();
         $data->{"$.title"} = "Hello";
@@ -30,7 +30,7 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals("Hello", $data->{"$.title"});
     }
 
-    public function testBracketSyntax()
+    public function testBracketSyntax(): void
     {
         $data = new RootedJsonData();
         $data->{"$[title]"} = "Hello";
@@ -38,14 +38,14 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals("Hello", $data->{"$[title]"});
     }
 
-    public function testAccessToNonExistentProperties()
+    public function testAccessToNonExistentProperties(): void
     {
         $data = new RootedJsonData();
         $this->assertNull($data->get("$.city"));
         $this->assertFalse(isset($data->{"$.city"}));
     }
 
-    public function testJsonFormat()
+    public function testJsonFormat(): void
     {
       // We want our data to keep its integrity in the in-betweens: From input to output.
         $this->expectExceptionMessage("Invalid JSON: Syntax error");
@@ -53,7 +53,7 @@ class RootedJsonDataTest extends TestCase
         new RootedJsonData($json);
     }
 
-    public function testJsonIntegrityFailure()
+    public function testJsonIntegrityFailure(): void
     {
         $json = '{"number":"hello"}';
         $schema = '{"type": "object","properties": {"number":{ "type": "number" }}}';
@@ -66,7 +66,7 @@ class RootedJsonDataTest extends TestCase
     }
 
     // Schema does not follow JSON Schema spec
-    public function testSchemaIntegrity()
+    public function testSchemaIntegrity(): void
     {
         $this->expectException(SchemaKeywordException::class);
         $json = '{"number":"hello"}';
@@ -76,7 +76,7 @@ class RootedJsonDataTest extends TestCase
     }
 
     // Schema is not even valid JSON
-    public function testSchemaJsonIntegrity()
+    public function testSchemaJsonIntegrity(): void
     {
         $this->expectException(InvalidSchemaException::class);
         $json = '{"number":"hello"}';
@@ -85,7 +85,7 @@ class RootedJsonDataTest extends TestCase
         new RootedJsonData($json, $schema);
     }
 
-    public function testJsonIntegrity()
+    public function testJsonIntegrity(): void
     {
         $json = '{"number":51}';
         $schema = '{"type": "object","properties":{"number":{"type":"number"}}}';
@@ -93,7 +93,7 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals($json, "{$data}");
     }
 
-    public function testJsonIntegrityFailureAfterChange()
+    public function testJsonIntegrityFailureAfterChange(): void
     {
         $this->expectExceptionMessage("\$.number expects a number");
 
@@ -107,7 +107,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Do schemas still work with magic setter?
      */
-    public function testJsonIntegrityFailureMagicSetter()
+    public function testJsonIntegrityFailureMagicSetter(): void
     {
         $this->expectExceptionMessage("\$[number] expects a number");
 
@@ -120,7 +120,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Simple get value from JSON path.
      */
-    public function testJsonPathGetter()
+    public function testJsonPathGetter(): void
     {
         $json = '{"container":{"number":51}}';
         $data = new RootedJsonData($json);
@@ -130,7 +130,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Simple set by JSON path.
      */
-    public function testJsonPathSetter()
+    public function testJsonPathSetter(): void
     {
         $json = '{"container":{"number":51}}';
         $data = new RootedJsonData($json);
@@ -141,7 +141,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Adding JSON structures in multiple formats should have predictable results.
      */
-    public function testAddJsonData()
+    public function testAddJsonData(): void
     {
         // Test adding RootedJsonData structure.
         $json = '{}';
@@ -162,7 +162,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * getSchema() should return the same string that was provided to constructor.
      */
-    public function testSchemaGetter()
+    public function testSchemaGetter(): void
     {
         $json = '{"number":51}';
         $schema = '{"type": "object","properties":{"number":{"type":"number"}}}';
@@ -173,7 +173,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Regular string should be one line, pretty() should return multiple lines.
      */
-    public function testPretty()
+    public function testPretty(): void
     {
         $json = '{"number":51}';
         $data = new RootedJsonData($json);
@@ -184,7 +184,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Adds string elements to an array.
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $json = '{"numbers":["zero","one","two"]}';
         $data = new RootedJsonData($json);
@@ -195,7 +195,7 @@ class RootedJsonDataTest extends TestCase
     /**
      * Adds object elements to an array.
      */
-    public function testAddObject()
+    public function testAddObject(): void
     {
         $json = '{"numbers":[{"name":"zero","value":0}]}';
         $data = new RootedJsonData($json);
@@ -207,7 +207,7 @@ class RootedJsonDataTest extends TestCase
      * If a schema is provided, adding elements that match array should work,
      * elements that violate schema will fail.
      */
-    public function testAddWithSchema()
+    public function testAddWithSchema(): void
     {
         $json = '{"numbers":["zero","one"]}';
         $schema = '{"type": "object","properties":{"numbers":{"type":"array","items":{"type":"string"}}}}';
@@ -222,7 +222,7 @@ class RootedJsonDataTest extends TestCase
      * If a schema is provided, adding elements that match array should work,
      * elements that violate schema will fail.
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $json = '{"field1":"foo","field2":"bar"}';
         $schema = '
@@ -249,7 +249,7 @@ class RootedJsonDataTest extends TestCase
      * If a schema is provided, adding elements that match array should work,
      * elements that violate schema will fail.
      */
-    public function testUnset()
+    public function testUnset(): void
     {
         $json = '{"field1":"foo","field2":"bar"}';
         $schema = '


### PR DESCRIPTION
- Pulls in new version of `opis/json-schema` after https://github.com/opis/json-schema/issues/151
- Minor Rector changes
- Adds PHP 8.4 to the testing matrix.