### PR TITLE
Make validation errors more specific

### DIFF
--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -25,6 +25,14 @@ class ValidationException extends \InvalidArgumentException
     public function __construct(string $message, ValidationResult $validationResult)
     {
         $this->validationResult = $validationResult;
+        $errors = $validationResult->getErrors();
+        $i =1;
+        foreach ($errors as $error) {
+            $pointer = implode(" -> ", $error->dataPointer());
+            $invalidValue = $error->data();
+            $message .= "\n {$i}) {$pointer}: {$invalidValue}";
+            $i++;
+        }
         parent::__construct($message);
     }
 

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -33,7 +33,7 @@ class ValidationException extends \InvalidArgumentException
             if (is_array($invalidValue) || is_object($invalidValue)) {
                 $invalidValue = json_encode($invalidValue);
             }
-            $message .= "\n {$i}) {$pointer}: {$invalidValue}";
+            $message .= "\n {$i}) {$pointer}: '{$invalidValue}'";
             $i++;
         }
         parent::__construct($message);

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -26,12 +26,15 @@ class ValidationException extends \InvalidArgumentException
     {
         $this->validationResult = $validationResult;
         $errors = $validationResult->getErrors();
-        $i =1;
+        $i = 1;
         foreach ($errors as $error) {
-            $pointer = implode(" -> ", $error->dataPointer());
-            (string) $invalidValue = $error->data();
-            $message .= "\n {$i}) {$pointer}: {$invalidValue}";
-            $i++;
+          $pointer = implode(" -> ", $error->dataPointer());
+          $invalidValue = $error->data();
+          if (is_array($invalidValue) || is_object($invalidValue)) {
+            $invalidValue = json_encode($invalidValue);
+          }
+          $message .= "\n {$i}) {$pointer}: {$invalidValue}";
+          $i++;
         }
         parent::__construct($message);
     }

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -28,11 +28,11 @@ class ValidationException extends \InvalidArgumentException
         $errors = $validationResult->getErrors();
         $i = 1;
         foreach ($errors as $error) {
-          $pointer = implode(" -> ", $error->dataPointer());
-          $invalidValue = $error->data();
-          if (is_array($invalidValue) || is_object($invalidValue)) {
-            $invalidValue = json_encode($invalidValue);
-          }
+            $pointer = implode(" -> ", $error->dataPointer());
+            $invalidValue = $error->data();
+            if (is_array($invalidValue) || is_object($invalidValue)) {
+                $invalidValue = json_encode($invalidValue);
+            }
           $message .= "\n {$i}) {$pointer}: {$invalidValue}";
           $i++;
         }

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -29,7 +29,7 @@ class ValidationException extends \InvalidArgumentException
         $i =1;
         foreach ($errors as $error) {
             $pointer = implode(" -> ", $error->dataPointer());
-            $invalidValue = $error->data();
+            (string) $invalidValue = $error->data();
             $message .= "\n {$i}) {$pointer}: {$invalidValue}";
             $i++;
         }

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -33,8 +33,8 @@ class ValidationException extends \InvalidArgumentException
             if (is_array($invalidValue) || is_object($invalidValue)) {
                 $invalidValue = json_encode($invalidValue);
             }
-          $message .= "\n {$i}) {$pointer}: {$invalidValue}";
-          $i++;
+            $message .= "\n {$i}) {$pointer}: {$invalidValue}";
+            $i++;
         }
         parent::__construct($message);
     }


### PR DESCRIPTION
Before
<img width="959" height="123" alt="Words with more questions than answeres" src="https://github.com/user-attachments/assets/6fb7267b-9318-4d5b-8986-c508ea1dd1fb" />


After

<img width="1002" height="167" alt="invalid describedByType" src="https://github.com/user-attachments/assets/fd513c32-98c4-457a-ae59-0c2753519ecc" />

Or 
<img width="976" height="99" alt="missing url" src="https://github.com/user-attachments/assets/04363437-464a-4d92-a980-83e4c6fff313" />


Closes #22 

Since this is done in the Exception class, this should address all 4 situations in RootedJsonData.php that call this exception and thereby improve all the output in the places where validation can fail in DKAN