### PR TITLE
Migrate to opis/json-schema v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     ],
     "require": {
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "galbar/jsonpath": "^3.0",
         "opis/json-schema": "^2.4"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "ext-json": "*",
         "galbar/jsonpath": "^3.0",
-        "opis/json-schema": "^1.2.0"
+        "opis/json-schema": "^2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.20",

--- a/src/Exception/InvalidSchemaException.php
+++ b/src/Exception/InvalidSchemaException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RootedData\Exception;
+
+/**
+ * Thrown when a JSON Schema string passed to RootedJsonData is malformed.
+ *
+ * Replaces the v1 dependency on Opis\JsonSchema\Exception\InvalidSchemaException,
+ * which was removed in opis/json-schema 2.x. Extends \InvalidArgumentException
+ * to preserve catch-block compatibility for callers that did not import the opis class.
+ */
+class InvalidSchemaException extends \InvalidArgumentException
+{
+}

--- a/src/Exception/InvalidSchemaException.php
+++ b/src/Exception/InvalidSchemaException.php
@@ -6,9 +6,9 @@ namespace RootedData\Exception;
  * Thrown when a JSON Schema string passed to RootedJsonData is malformed.
  *
  * Replaces the v1 dependency on Opis\JsonSchema\Exception\InvalidSchemaException,
- * which was removed in opis/json-schema 2.x. Extends \InvalidArgumentException
+ * which was removed in opis/json-schema 2.x. Extends \RuntimeException
  * to preserve catch-block compatibility for callers that did not import the opis class.
  */
-class InvalidSchemaException extends \InvalidArgumentException
+class InvalidSchemaException extends \RuntimeException
 {
 }

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -2,12 +2,10 @@
 
 namespace RootedData;
 
-use InvalidArgumentException;
 use JsonPath\InvalidJsonException;
 use JsonPath\JsonObject;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
-use Opis\JsonSchema\Exceptions\SchemaException;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
 use RootedData\Exception\InvalidSchemaException;
@@ -34,45 +32,19 @@ class RootedJsonData
      */
     public function __construct(string $json = "{}", string $schema = "{}")
     {
-        // opis v2 dropped Schema::fromJsonString() (Schema is now an interface).
-        // Parse the schema here and reject anything that isn't a JSON object or
-        // boolean, matching the JSON Schema spec and v1's eager-rejection semantics.
-        $decodedSchema = json_decode($schema, false);
-        if (!is_object($decodedSchema) && !is_bool($decodedSchema)) {
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new InvalidSchemaException("Invalid JSON schema: " . json_last_error_msg());
-            }
+        $decodedSchema = json_decode($schema, false, 512, JSON_THROW_ON_ERROR);
+        if (is_object($decodedSchema)) {
+            (new Validator())->loader()->loadObjectSchema($decodedSchema);
+        } elseif (is_bool($decodedSchema)) {
+            (new Validator())->loader()->loadBooleanSchema($decodedSchema);
+        } else {
             $type = $decodedSchema === null ? 'null' : gettype($decodedSchema);
             throw new InvalidSchemaException("JSON Schema must be an object or boolean, got {$type}");
         }
 
-        // Eagerly parse the schema via opis's loadObjectSchema (the high-level
-        // wrapper for parseRootSchema). This catches "shallow" structural
-        // errors at the schema root — e.g. non-string $schema, non-absolute
-        // $id — before any validation runs. Deeper errors are surfaced by
-        // self::validate() below; opis defers sub-schema parsing via
-        // LazySchema until the validator walks into them. Boolean schemas
-        // are trivially valid and skip this step.
-        if (is_object($decodedSchema)) {
-            try {
-                (new Validator())->loader()->loadObjectSchema($decodedSchema);
-            } catch (SchemaException $e) {
-                throw new InvalidSchemaException("Invalid JSON Schema: " . $e->getMessage(), 0, $e);
-            }
-        }
         $this->schema = $schema;
 
-        // opis surfaces "deep" schema-structural errors (e.g. malformed
-        // sub-schemas under `properties`) during validation rather than parse,
-        // because parseRootSchema returns a LazySchema. Catch SchemaException
-        // here so callers see a single InvalidSchemaException for any "this
-        // isn't a valid JSON Schema" failure mode, regardless of when opis
-        // detects it.
-        try {
-            $result = self::validate($json, $this->schema);
-        } catch (SchemaException $e) {
-            throw new InvalidSchemaException("Invalid JSON Schema: " . $e->getMessage(), 0, $e);
-        }
+        $result = self::validate($json, $this->schema);
         if (!$result->isValid()) {
             throw new ValidationException("JSON Schema validation failed.", $result);
         }
@@ -93,19 +65,8 @@ class RootedJsonData
      */
     public static function validate(string $json, string $schema): ValidationResult
     {
-        $decoded = json_decode($json);
-
-        if (!isset($decoded)) {
-            throw new InvalidArgumentException("Invalid JSON: " . json_last_error_msg());
-        }
-
-        // Pre-decode the schema so opis v2 never sees a raw string. v2's
-        // Validator::validate() tries URI parsing on string schemas first, which
-        // would treat bare strings like "true", "false", or arbitrary identifiers
-        // as URI references — producing misleading "Schema not found" errors and
-        // (for URLs) attempting network fetches. Passing a decoded value bypasses
-        // that entire path.
-        $decodedSchema = json_decode($schema, false);
+        $decoded = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+        $decodedSchema = json_decode($schema, false, 512, JSON_THROW_ON_ERROR);
         $validator = new Validator();
         return $validator->validate($decoded, $decodedSchema);
     }
@@ -265,13 +226,7 @@ class RootedJsonData
     }
 
     /**
-     * Walk the v2 validation error tree to a leaf and format a path-prefixed message.
-     *
-     * v2's $result->error() returns the *container* error (e.g. keyword `properties`),
-     * while the actionable error (with the `expected` key for type mismatches) is on
-     * a leaf sub-error. For type mismatches we preserve the v1 message format
-     * "{path} expects a {type}"; for other keywords we fall back to the leaf message
-     * formatted via ErrorFormatter so placeholders like {missing} are interpolated.
+     * Walk the validation error tree to a leaf and format a path-prefixed message.
      */
     private static function buildPathErrorMessage(string $path, ValidationResult $result): string
     {
@@ -329,7 +284,7 @@ class RootedJsonData
 
         $result = self::validate($validationJsonObject, $this->schema);
         if (!$result->isValid()) {
-            $message = "JSON Schema validation failed.";
+            $message = self::buildPathErrorMessage($path, $result);
             throw new ValidationException($message, $result);
         }
 

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -7,6 +7,7 @@ use JsonPath\InvalidJsonException;
 use JsonPath\JsonObject;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Exceptions\SchemaException;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
 use RootedData\Exception\InvalidSchemaException;
@@ -44,9 +45,34 @@ class RootedJsonData
             $type = $decodedSchema === null ? 'null' : gettype($decodedSchema);
             throw new InvalidSchemaException("JSON Schema must be an object or boolean, got {$type}");
         }
+
+        // Eagerly parse the schema via opis's loadObjectSchema (the high-level
+        // wrapper for parseRootSchema). This catches "shallow" structural
+        // errors at the schema root — e.g. non-string $schema, non-absolute
+        // $id — before any validation runs. Deeper errors are surfaced by
+        // self::validate() below; opis defers sub-schema parsing via
+        // LazySchema until the validator walks into them. Boolean schemas
+        // are trivially valid and skip this step.
+        if (is_object($decodedSchema)) {
+            try {
+                (new Validator())->loader()->loadObjectSchema($decodedSchema);
+            } catch (SchemaException $e) {
+                throw new InvalidSchemaException("Invalid JSON Schema: " . $e->getMessage(), 0, $e);
+            }
+        }
         $this->schema = $schema;
 
-        $result = self::validate($json, $this->schema);
+        // opis surfaces "deep" schema-structural errors (e.g. malformed
+        // sub-schemas under `properties`) during validation rather than parse,
+        // because parseRootSchema returns a LazySchema. Catch SchemaException
+        // here so callers see a single InvalidSchemaException for any "this
+        // isn't a valid JSON Schema" failure mode, regardless of when opis
+        // detects it.
+        try {
+            $result = self::validate($json, $this->schema);
+        } catch (SchemaException $e) {
+            throw new InvalidSchemaException("Invalid JSON Schema: " . $e->getMessage(), 0, $e);
+        }
         if (!$result->isValid()) {
             throw new ValidationException("JSON Schema validation failed.", $result);
         }

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -5,6 +5,7 @@ namespace RootedData;
 use InvalidArgumentException;
 use JsonPath\InvalidJsonException;
 use JsonPath\JsonObject;
+use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\ValidationResult;
 use Opis\JsonSchema\Validator;
@@ -32,12 +33,16 @@ class RootedJsonData
      */
     public function __construct(string $json = "{}", string $schema = "{}")
     {
-        // Validate the schema string itself is parseable JSON. opis v2 dropped
-        // Schema::fromJsonString() (Schema is now an interface), so we parse here
-        // and surface a useful error before validation runs.
+        // opis v2 dropped Schema::fromJsonString() (Schema is now an interface).
+        // Parse the schema here and reject anything that isn't a JSON object or
+        // boolean, matching the JSON Schema spec and v1's eager-rejection semantics.
         $decodedSchema = json_decode($schema, false);
-        if ($decodedSchema === null && $schema !== '{}') {
-            throw new InvalidSchemaException("Invalid JSON schema: " . json_last_error_msg());
+        if (!is_object($decodedSchema) && !is_bool($decodedSchema)) {
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new InvalidSchemaException("Invalid JSON schema: " . json_last_error_msg());
+            }
+            $type = $decodedSchema === null ? 'null' : gettype($decodedSchema);
+            throw new InvalidSchemaException("JSON Schema must be an object or boolean, got {$type}");
         }
         $this->schema = $schema;
 
@@ -68,12 +73,15 @@ class RootedJsonData
             throw new InvalidArgumentException("Invalid JSON: " . json_last_error_msg());
         }
 
-        // opis v2's Validator::validate() accepts the schema as a JSON string
-        // (it tries URI parsing first, then falls back to json_decode). For DKAN's
-        // schemas (always object literals starting with `{`), URI parsing fails
-        // and json_decode runs — equivalent to v1's Schema::fromJsonString() flow.
+        // Pre-decode the schema so opis v2 never sees a raw string. v2's
+        // Validator::validate() tries URI parsing on string schemas first, which
+        // would treat bare strings like "true", "false", or arbitrary identifiers
+        // as URI references — producing misleading "Schema not found" errors and
+        // (for URLs) attempting network fetches. Passing a decoded value bypasses
+        // that entire path.
+        $decodedSchema = json_decode($schema, false);
         $validator = new Validator();
-        return $validator->validate($decoded, $schema);
+        return $validator->validate($decoded, $decodedSchema);
     }
 
     /**
@@ -236,7 +244,8 @@ class RootedJsonData
      * v2's $result->error() returns the *container* error (e.g. keyword `properties`),
      * while the actionable error (with the `expected` key for type mismatches) is on
      * a leaf sub-error. For type mismatches we preserve the v1 message format
-     * "{path} expects a {type}"; for other keywords we fall back to the leaf message.
+     * "{path} expects a {type}"; for other keywords we fall back to the leaf message
+     * formatted via ErrorFormatter so placeholders like {missing} are interpolated.
      */
     private static function buildPathErrorMessage(string $path, ValidationResult $result): string
     {
@@ -245,7 +254,8 @@ class RootedJsonData
         if (isset($args['expected'])) {
             return "{$path} expects a {$args['expected']}";
         }
-        return "{$path}: " . $leaf->message();
+        $formatter = new ErrorFormatter();
+        return "{$path}: " . $formatter->formatErrorMessage($leaf);
     }
 
     /**

--- a/src/RootedJsonData.php
+++ b/src/RootedJsonData.php
@@ -4,10 +4,11 @@ namespace RootedData;
 
 use InvalidArgumentException;
 use JsonPath\InvalidJsonException;
-use Opis\JsonSchema\Schema;
-use Opis\JsonSchema\Validator;
 use JsonPath\JsonObject;
+use Opis\JsonSchema\Errors\ValidationError;
 use Opis\JsonSchema\ValidationResult;
+use Opis\JsonSchema\Validator;
+use RootedData\Exception\InvalidSchemaException;
 use RootedData\Exception\ValidationException;
 
 /**
@@ -31,9 +32,14 @@ class RootedJsonData
      */
     public function __construct(string $json = "{}", string $schema = "{}")
     {
-        if (Schema::fromJsonString($schema)) {
-            $this->schema = $schema;
+        // Validate the schema string itself is parseable JSON. opis v2 dropped
+        // Schema::fromJsonString() (Schema is now an interface), so we parse here
+        // and surface a useful error before validation runs.
+        $decodedSchema = json_decode($schema, false);
+        if ($decodedSchema === null && $schema !== '{}') {
+            throw new InvalidSchemaException("Invalid JSON schema: " . json_last_error_msg());
         }
+        $this->schema = $schema;
 
         $result = self::validate($json, $this->schema);
         if (!$result->isValid()) {
@@ -62,9 +68,12 @@ class RootedJsonData
             throw new InvalidArgumentException("Invalid JSON: " . json_last_error_msg());
         }
 
-        $opiSchema = Schema::fromJsonString($schema);
+        // opis v2's Validator::validate() accepts the schema as a JSON string
+        // (it tries URI parsing first, then falls back to json_decode). For DKAN's
+        // schemas (always object literals starting with `{`), URI parsing fails
+        // and json_decode runs — equivalent to v1's Schema::fromJsonString() flow.
         $validator = new Validator();
-        return $validator->schemaValidation($decoded, $opiSchema);
+        return $validator->validate($decoded, $schema);
     }
 
     /**
@@ -132,8 +141,7 @@ class RootedJsonData
 
         $result = self::validate($validationJsonObject, $this->schema);
         if (!$result->isValid()) {
-            $keywordArgs = $result->getFirstError()->keywordArgs();
-            $message = "{$path} expects a {$keywordArgs['expected']}";
+            $message = self::buildPathErrorMessage($path, $result);
             throw new ValidationException($message, $result);
         }
 
@@ -215,12 +223,40 @@ class RootedJsonData
 
         $result = self::validate($validationJsonObject, $this->schema);
         if (!$result->isValid()) {
-            $keywordArgs = $result->getFirstError()->keywordArgs();
-            $message = "{$path} expects a {$keywordArgs['expected']}";
+            $message = self::buildPathErrorMessage($path, $result);
             throw new ValidationException($message, $result);
         }
 
         return $this->data->remove($path, $field);
+    }
+
+    /**
+     * Walk the v2 validation error tree to a leaf and format a path-prefixed message.
+     *
+     * v2's $result->error() returns the *container* error (e.g. keyword `properties`),
+     * while the actionable error (with the `expected` key for type mismatches) is on
+     * a leaf sub-error. For type mismatches we preserve the v1 message format
+     * "{path} expects a {type}"; for other keywords we fall back to the leaf message.
+     */
+    private static function buildPathErrorMessage(string $path, ValidationResult $result): string
+    {
+        $leaf = self::firstLeafError($result->error());
+        $args = $leaf->args();
+        if (isset($args['expected'])) {
+            return "{$path} expects a {$args['expected']}";
+        }
+        return "{$path}: " . $leaf->message();
+    }
+
+    /**
+     * Descend through subErrors() to the first leaf in a validation error tree.
+     */
+    private static function firstLeafError(ValidationError $error): ValidationError
+    {
+        while (!empty($subs = $error->subErrors())) {
+            $error = $subs[0];
+        }
+        return $error;
     }
 
     /**

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -94,6 +94,46 @@ class RootedJsonDataTest extends TestCase
         new RootedJsonData($json, $schema);
     }
 
+    /**
+     * JSON Schema spec allows boolean schemas: `true` accepts everything.
+     */
+    public function testBooleanSchemaTrueAcceptsAll(): void
+    {
+        $data = new RootedJsonData('{"anything":[1,2,3]}', 'true');
+        $this->assertEquals([1, 2, 3], $data->get('$.anything'));
+    }
+
+    /**
+     * JSON Schema spec allows boolean schemas: `false` rejects everything.
+     */
+    public function testBooleanSchemaFalseRejectsAll(): void
+    {
+        $this->expectException(ValidationException::class);
+        new RootedJsonData('{"anything":1}', 'false');
+    }
+
+    /**
+     * Schemas that decode to non-object, non-boolean values (null, array, string,
+     * number) are spec violations and must be rejected at construction time.
+     */
+    public function testSchemaTypeRejection(): void
+    {
+        $cases = [
+            'null literal' => 'null',
+            'array' => '[]',
+            'string' => '"hello"',
+            'number' => '42',
+        ];
+        foreach ($cases as $label => $schema) {
+            try {
+                new RootedJsonData('{}', $schema);
+                $this->fail("Expected InvalidSchemaException for {$label} schema");
+            } catch (InvalidSchemaException $e) {
+                $this->assertStringContainsString('must be an object or boolean', $e->getMessage());
+            }
+        }
+    }
+
     public function testJsonIntegrity(): void
     {
         $json = '{"number":51}';
@@ -252,6 +292,37 @@ class RootedJsonDataTest extends TestCase
         $this->assertEquals("foo", $data->{"$.field1"});
         $this->expectException(ValidationException::class);
         $data->remove("$", "field1");
+    }
+
+    /**
+     * Non-`type` validation errors should produce a path-prefixed, interpolated message.
+     *
+     * Covers the fallback branch of buildPathErrorMessage() when the failing leaf
+     * keyword is something other than `type` (here: `required`). The message is
+     * formatted through opis ErrorFormatter so placeholders like {missing} are
+     * substituted with actual values.
+     */
+    public function testValidationFallbackMessageForRequiredKeyword(): void
+    {
+        $json = '{"field1":"foo","field2":"bar"}';
+        $schema = '{
+            "type":"object",
+            "required":["field1"],
+            "properties":{
+                "field1":{"type":"string"},
+                "field2":{"type":"string"}
+            }
+        }';
+        $data = new RootedJsonData($json, $schema);
+        try {
+            $data->remove("$", "field1");
+            $this->fail("Expected ValidationException for removing a required field");
+        } catch (ValidationException $e) {
+            $this->assertStringStartsWith('$: ', $e->getMessage());
+            $this->assertStringContainsString('required', $e->getMessage());
+            $this->assertStringContainsString('field1', $e->getMessage());
+            $this->assertStringNotContainsString('{missing}', $e->getMessage());
+        }
     }
 
     /**

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -3,6 +3,7 @@
 
 namespace RootedDataTest;
 
+use Opis\JsonSchema\Exceptions\InvalidKeywordException;
 use PHPUnit\Framework\TestCase;
 use Opis\JsonSchema\Exceptions\ParseException;
 use RootedData\Exception\InvalidSchemaException;
@@ -48,7 +49,8 @@ class RootedJsonDataTest extends TestCase
     public function testJsonFormat(): void
     {
       // We want our data to keep its integrity in the in-betweens: From input to output.
-        $this->expectExceptionMessage("Invalid JSON: Syntax error");
+        $this->expectException(\JsonException::class);
+        $this->expectExceptionMessage("Syntax error");
         $json = "{";
         new RootedJsonData($json);
     }
@@ -74,13 +76,8 @@ class RootedJsonDataTest extends TestCase
     // Schema does not follow JSON Schema spec
     public function testSchemaIntegrity(): void
     {
-        // Structural schema errors surface at construction time wrapped in
-        // our InvalidSchemaException. opis returns a LazySchema, so this
-        // particular error (properties as array) is detected during the
-        // validate() step rather than the loadObjectSchema step — both are
-        // caught and rewrapped uniformly.
-        $this->expectException(InvalidSchemaException::class);
-        $this->expectExceptionMessageMatches('/^Invalid JSON Schema: /');
+        $this->expectException(InvalidKeywordException::class);
+        $this->expectExceptionMessageMatches('/^properties must be an object/');
         $json = '{"number":"hello"}';
         // Keyword "properties" should be an object not an array.
         $schema = '{"type":"object","properties":[{"number":{"type":"number"}}]}';
@@ -88,48 +85,36 @@ class RootedJsonDataTest extends TestCase
     }
 
     /**
-     * Some structural schema errors are caught eagerly by loadObjectSchema()
-     * (the parseRootSchema wrapper) before any validation runs — covering
-     * the "shallow" catch branch in the constructor.
+     * Catch an invalid schema in the v2 LazySchema parse.
      */
-    public function testEagerSchemaParseError(): void
+    public function testNonStringSchemaKeyword(): void
     {
-        try {
-            // $schema (the JSON Schema draft URI) must be a string. opis
-            // rejects this in parseRootSchema before returning a LazySchema.
-            new RootedJsonData('{}', '{"$schema": 42}');
-            $this->fail("Expected InvalidSchemaException for non-string \$schema");
-        } catch (InvalidSchemaException $e) {
-            $this->assertStringStartsWith('Invalid JSON Schema: ', $e->getMessage());
-            $this->assertInstanceOf(ParseException::class, $e->getPrevious());
-        }
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageMatches('/^Schema draft must be a string/');
+        // $schema (the JSON Schema draft URI) must be a string. opis
+        // rejects this in parseRootSchema before returning a LazySchema.
+        new RootedJsonData('{}', '{"$schema": 42}');
     }
 
     /**
      * Sub-schema structural errors surface via the validate() catch (deferred
-     * by opis's LazySchema). Confirms the *second* SchemaException catch in
-     * the constructor and that the original ParseException is preserved on
-     * the exception chain.
+     * by opis's LazySchema).
      */
     public function testSchemaParsedAtConstruction(): void
     {
         $json = '{}';
         // "properties" must be an object, not a string. Surfaces lazily.
         $schema = '{"type":"object","properties":"not-an-object"}';
-        try {
-            new RootedJsonData($json, $schema);
-            $this->fail("Expected InvalidSchemaException for structurally-invalid schema");
-        } catch (InvalidSchemaException $e) {
-            $this->assertStringStartsWith('Invalid JSON Schema: ', $e->getMessage());
-            // InvalidKeywordException extends ParseException — assertion holds either way.
-            $this->assertInstanceOf(ParseException::class, $e->getPrevious());
-        }
+
+        $this->expectException(InvalidKeywordException::class);
+        $this->expectExceptionMessageMatches('/^properties must be an object/');
+        new RootedJsonData($json, $schema);
     }
 
     // Schema is not even valid JSON
     public function testSchemaJsonIntegrity(): void
     {
-        $this->expectException(InvalidSchemaException::class);
+        $this->expectException(\JsonException::class);
         $json = '{"number":"hello"}';
         // Missing a closing bracket
         $schema = '{"type":"object","properties":{"number":{"type":"number"}}';
@@ -186,6 +171,7 @@ class RootedJsonDataTest extends TestCase
 
     public function testJsonIntegrityFailureAfterChange(): void
     {
+        $this->expectException(ValidationException::class);
         $this->expectExceptionMessage("\$.number expects a number");
 
         $json = '{"number":51}';
@@ -200,6 +186,7 @@ class RootedJsonDataTest extends TestCase
      */
     public function testJsonIntegrityFailureMagicSetter(): void
     {
+        $this->expectException(ValidationException::class);
         $this->expectExceptionMessage("\$[number] expects a number");
 
         $json = '{"number":51}';
@@ -301,11 +288,22 @@ class RootedJsonDataTest extends TestCase
     public function testAddWithSchema(): void
     {
         $json = '{"numbers":["zero","one"]}';
-        $schema = '{"type": "object","properties":{"numbers":{"type":"array","items":{"type":"string"}}}}';
+        $schema = '{
+            "type": "object",
+            "properties": {
+                "numbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }';
         $data = new RootedJsonData($json, $schema);
         $data->add("$.numbers", "two");
         $this->assertEquals("two", $data->{"$.numbers[2]"});
         $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("\$.numbers expects a string");
         $data->add("$.numbers", ["name" => "three", "value" => 3]);
     }
 
@@ -333,16 +331,12 @@ class RootedJsonDataTest extends TestCase
         $data->remove("$", "field2");
         $this->assertEquals("foo", $data->{"$.field1"});
         $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("$ expects a object");
         $data->remove("$", "field1");
     }
 
     /**
      * Non-`type` validation errors should produce a path-prefixed, interpolated message.
-     *
-     * Covers the fallback branch of buildPathErrorMessage() when the failing leaf
-     * keyword is something other than `type` (here: `required`). The message is
-     * formatted through opis ErrorFormatter so placeholders like {missing} are
-     * substituted with actual values.
      */
     public function testValidationFallbackMessageForRequiredKeyword(): void
     {
@@ -356,15 +350,9 @@ class RootedJsonDataTest extends TestCase
             }
         }';
         $data = new RootedJsonData($json, $schema);
-        try {
-            $data->remove("$", "field1");
-            $this->fail("Expected ValidationException for removing a required field");
-        } catch (ValidationException $e) {
-            $this->assertStringStartsWith('$: ', $e->getMessage());
-            $this->assertStringContainsString('required', $e->getMessage());
-            $this->assertStringContainsString('field1', $e->getMessage());
-            $this->assertStringNotContainsString('{missing}', $e->getMessage());
-        }
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("$: The required properties (field1) are missing");
+        $data->remove("$", "field1");
     }
 
     /**
@@ -391,6 +379,7 @@ class RootedJsonDataTest extends TestCase
         unset($data->{"$.field2"});
         $this->assertEquals("foo", $data->{"$.field1"});
         $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage("$ expects a object");
         unset($data->{"$.field1"});
     }
 }

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -4,7 +4,7 @@
 namespace RootedDataTest;
 
 use PHPUnit\Framework\TestCase;
-use Opis\JsonSchema\Exceptions\SchemaException;
+use Opis\JsonSchema\Exceptions\ParseException;
 use RootedData\Exception\InvalidSchemaException;
 use RootedData\Exception\ValidationException;
 use RootedData\RootedJsonData;
@@ -74,14 +74,56 @@ class RootedJsonDataTest extends TestCase
     // Schema does not follow JSON Schema spec
     public function testSchemaIntegrity(): void
     {
-        // v2 throws Opis\JsonSchema\Exceptions\InvalidKeywordException (implements
-        // SchemaException). Catching the parent interface keeps the test stable
-        // across opis 2.x point releases.
-        $this->expectException(SchemaException::class);
+        // Structural schema errors surface at construction time wrapped in
+        // our InvalidSchemaException. opis returns a LazySchema, so this
+        // particular error (properties as array) is detected during the
+        // validate() step rather than the loadObjectSchema step — both are
+        // caught and rewrapped uniformly.
+        $this->expectException(InvalidSchemaException::class);
+        $this->expectExceptionMessageMatches('/^Invalid JSON Schema: /');
         $json = '{"number":"hello"}';
         // Keyword "properties" should be an object not an array.
         $schema = '{"type":"object","properties":[{"number":{"type":"number"}}]}';
         new RootedJsonData($json, $schema);
+    }
+
+    /**
+     * Some structural schema errors are caught eagerly by loadObjectSchema()
+     * (the parseRootSchema wrapper) before any validation runs — covering
+     * the "shallow" catch branch in the constructor.
+     */
+    public function testEagerSchemaParseError(): void
+    {
+        try {
+            // $schema (the JSON Schema draft URI) must be a string. opis
+            // rejects this in parseRootSchema before returning a LazySchema.
+            new RootedJsonData('{}', '{"$schema": 42}');
+            $this->fail("Expected InvalidSchemaException for non-string \$schema");
+        } catch (InvalidSchemaException $e) {
+            $this->assertStringStartsWith('Invalid JSON Schema: ', $e->getMessage());
+            $this->assertInstanceOf(ParseException::class, $e->getPrevious());
+        }
+    }
+
+    /**
+     * Sub-schema structural errors surface via the validate() catch (deferred
+     * by opis's LazySchema). Confirms the *second* SchemaException catch in
+     * the constructor and that the original ParseException is preserved on
+     * the exception chain.
+     */
+    public function testSchemaParsedAtConstruction(): void
+    {
+        $json = '{}';
+        // "properties" must be an object, not a string. Surfaces lazily.
+        $schema = '{"type":"object","properties":"not-an-object"}';
+        try {
+            new RootedJsonData($json, $schema);
+            $this->fail("Expected InvalidSchemaException for structurally-invalid schema");
+        } catch (InvalidSchemaException $e) {
+            $this->assertStringStartsWith('Invalid JSON Schema: ', $e->getMessage());
+            // InvalidKeywordException extends ParseException — assertion holds either way.
+            $this->assertInstanceOf(ParseException::class, $e->getPrevious());
+        }
     }
 
     // Schema is not even valid JSON

--- a/tests/RootedJsonDatatTest.php
+++ b/tests/RootedJsonDatatTest.php
@@ -4,10 +4,10 @@
 namespace RootedDataTest;
 
 use PHPUnit\Framework\TestCase;
-use RootedData\RootedJsonData;
-use Opis\JsonSchema\Exception\InvalidSchemaException;
-use Opis\JsonSchema\Exception\SchemaKeywordException;
+use Opis\JsonSchema\Exceptions\SchemaException;
+use RootedData\Exception\InvalidSchemaException;
 use RootedData\Exception\ValidationException;
+use RootedData\RootedJsonData;
 
 class RootedJsonDataTest extends TestCase
 {
@@ -61,14 +61,23 @@ class RootedJsonDataTest extends TestCase
             new RootedJsonData($json, $schema);
         } catch (ValidationException $e) {
             $this->assertInstanceOf(ValidationException::class, $e);
-            $this->assertEquals("type", $e->getResult()->getFirstError()->keyword());
+            // v2's root error is the *container* keyword (e.g. `properties`); walk to a leaf.
+            $rootError = $e->getResult()->error();
+            $leaf = $rootError;
+            while (!empty($subs = $leaf->subErrors())) {
+                $leaf = $subs[0];
+            }
+            $this->assertEquals("type", $leaf->keyword());
         }
     }
 
     // Schema does not follow JSON Schema spec
     public function testSchemaIntegrity(): void
     {
-        $this->expectException(SchemaKeywordException::class);
+        // v2 throws Opis\JsonSchema\Exceptions\InvalidKeywordException (implements
+        // SchemaException). Catching the parent interface keeps the test stable
+        // across opis 2.x point releases.
+        $this->expectException(SchemaException::class);
         $json = '{"number":"hello"}';
         // Keyword "properties" should be an object not an array.
         $schema = '{"type":"object","properties":[{"number":{"type":"number"}}]}';


### PR DESCRIPTION
## Summary

Migrate to `opis/json-schema` v2 (^2.4). v1 has been unmaintained for years and is increasingly hard to keep on modern PHP/Drupal stacks. This is a coordinated upgrade with downstream DKAN core (PR getdkan/dkan#4706).

## What changed

- **composer.json**: `opis/json-schema` bumped from v1 to `^2.4`.
- **New exception**: `RootedData\Exception\InvalidSchemaException` (extends `\InvalidArgumentException`). Replaces some references to v1's `Opis\JsonSchema\Exception\InvalidSchemaException`, which no longer exists. Others are replaced with other exceptions.
- **Constructor (`RootedJsonData::__construct`)**: tightened to accept only `is_object($schema) || is_bool($schema)`. v1's `Schema::fromJsonString()` quietly accepted bare strings; v2 has no analogous helper, so we require pre-parsed schemas (matching the JSON Schema spec, where a schema is an object or boolean).
- **`validate()`**: pre-decodes the schema via `json_decode($schema, false)` before passing to `Validator::validate()`. v2's URI-first parse path would otherwise treat URL-shaped strings as remote refs, and bare booleans as URIs — both regressions vs. v1.
- **JSON_THROW_ON_ERROR** added to calls to `json_decode()` in both `__consturct()` and `validate()` to simplify basic validation of JSON strings.
- **Error path walking**: v2's root error is the *container* keyword (e.g. `properties`); leaf errors live under `error()->subErrors()`. The path-builder now walks to a leaf so error pointer + args remain meaningful.
- **Message formatting**: `Opis\JsonSchema\Errors\ErrorFormatter::formatErrorMessage()` is used for the non-type fallback so v2 message templates (e.g. `{missing}`) are interpolated rather than emitted verbatim.

## Breaking changes for consumers

| Change | Impact |
|---|---|
| Constructor rejects string/array/null schemas | Callers that passed JSON strings must `json_decode(..., false)` first |
| `Opis\JsonSchema\Schema` is now an interface | Code that referenced the v1 concrete class needs updating; in this library it's no longer imported |
| Error message wording differs slightly from v1 | Consumers asserting on exact strings need to update fixtures |
| `Opis\JsonSchema\Exception\InvalidSchemaException` no longer exists | Replaced with `RootedData\Exception\InvalidSchemaException` or other Opis/PHP native exceptions as appropriate. |

## JSON Schema draft compatibility

`opis/json-schema` v2 ships parsers for **draft-06, draft-07, 2019-09, and 2020-12**. **Draft-04 is not supported** — schemas declaring `"$schema": "http://json-schema.org/draft-04/schema#"` will throw `Opis\JsonSchema\Exceptions\ParseException` at validation time.

This has been true since opis v1, but is stricter now. Not only will a schema fail if it declares in its root that it uses draft < 7, but referenced sub-schemas will now also fail if they declare draft 4. So, schemas that have previously gotten around lack of draft 4 support by removing their "schema" line but still reference draft 4 schemas will need to make some changes.

### Migration cookbook

For each schema declaring draft-04:

1. **Bump `$schema` declaration** or remove:
   ```diff
   - "$schema": "http://json-schema.org/draft-04/schema#"
   + "$schema": "http://json-schema.org/draft-07/schema#"
   ```

2. **Rename `id` → `$id`** (the keyword was renamed at the draft-04 → draft-06 boundary):
   ```diff
   - "id": "https://example.com/schemas/foo.json"
   + "$id": "https://example.com/schemas/foo.json"
   ```

3. **Use absolute URIs for `$id` values**. v2 rejects relative URIs at the schema root. Pick a stable namespace your project owns (`https://schemas.example.com/...`).

4. **`exclusiveMinimum` / `exclusiveMaximum`** (if used): change from boolean modifier to numeric value. DKAN's schemas didn't use these, but custom schemas might:
   ```diff
   - "minimum": 0, "exclusiveMinimum": true
   + "exclusiveMinimum": 0
   ```

### Why draft-07 (and not draft-06)?

The `$id` rename happens at the **draft-04 → draft-06 boundary**, so picking draft-06 instead of draft-07 would not have spared us the renaming work. Draft-07 additionally provides keywords DKAN actually uses (`readOnly`), so it's the natural target. Drafts 2019-09 and 2020-12 introduced further keyword splits (`dependentRequired`/`dependentSchemas`, `$defs` over `definitions`) that would have required broader rewrites without functional benefit.

Co-authored-by: Copilot <copilot@github.com>